### PR TITLE
LPFTD-38 - LPFTD-38-members-can-have-only-five-books-out-at-a-time-trigger-stored-procedure

### DIFF
--- a/Application/Contracts/Persistence/IBorrowOrderRepository.cs
+++ b/Application/Contracts/Persistence/IBorrowOrderRepository.cs
@@ -8,6 +8,7 @@ namespace Application.Contracts.Persistence
     public interface IBorrowOrderRepository : IAsyncRepository<BorrowOrder>
     {
         Task<IEnumerable<BorrowOrder>> GetAllAsync();
+        Task<int> GetCountOfUnreturnedOrders(int ssn);
     }
 
 

--- a/Application/Features/BorrowOrder/Commands/CreateBorrowOder/CreateBorrowOrderCommandHandler.cs
+++ b/Application/Features/BorrowOrder/Commands/CreateBorrowOder/CreateBorrowOrderCommandHandler.cs
@@ -16,7 +16,11 @@ namespace Application.Features.BorrowOrder.Commands.CreateBorrowOrder
         }
 
         public async Task<Result> Handle(CreateBorrowOrderCommand command, CancellationToken cancellationToken = default)
-        {       
+        {
+            if (await borrowOrderRepository.GetCountOfUnreturnedOrders(command.Borrower.SSN) >= 5)
+            {
+                return Result.Fail(Errors.General.UnexpectedValue("You are not allowed to borrow more than five books."));
+            }
             var borrowOrder = new Domain.AggregateRoots.BorrowOrder(command.BorrowDate, command.Borrower, command.Librarian, command.Item);
             var orderId = await this.borrowOrderRepository.AddAsync(borrowOrder);
             return Result.Ok(orderId);

--- a/DAL/BorrowOrderRepository.cs
+++ b/DAL/BorrowOrderRepository.cs
@@ -70,5 +70,14 @@ namespace DAL
                 return await conn.ExecuteAsync("DELETE FROM [BorrowOrder] WHERE OrderID = @ID", new { ID = id });
             }
         }
+
+        public async Task<int> GetCountOfUnreturnedOrders(int userSSN)
+        {
+            using (var conn = dataContext.CreateConnection())
+            {
+                return await conn.QuerySingleAsync<int>("dbo.GetNumberOfBorrowedBooksByUserId @id", new { id = userSSN});
+            }
+        }
+
     }
 }

--- a/UnitTests.DAL/DAL_Get_Unreturned_Orders_Tests.cs
+++ b/UnitTests.DAL/DAL_Get_Unreturned_Orders_Tests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using DAL;
+using Domain.AggregateRoots;
+using Domain.Entities;
+using Xunit;
+
+namespace UnitTests.DAL
+{
+    public class DAL_Get_Unreturned_Orders_Tests
+    {
+        public DataContext dataContext { get; set; }
+        public BorrowOrderRepository rep { get; set; }
+
+        public DAL_Get_Unreturned_Orders_Tests()
+        {
+            //Configuration = configuration;
+            string connectionString = "Server=localhost,1433;User Id=sa;Password=MyPass@word;Database=LibraryDatabase;MultipleActiveResultSets=true";
+            dataContext = new DataContext(connectionString);
+            rep = new BorrowOrderRepository(dataContext);
+        }
+
+        [Fact]
+        public async Task GetCountOfUnreturnedOrdersTestAsync()
+        {
+            LibUser member = new LibUser() { SSN = 1234556 };
+            LibUser librarian = new LibUser(1067572636, "Lamar", "Rice", "576 First St.", 124751394, "Hawaii", MemberType.Student, LibrarianType.Admin);
+            BorrowOrder order = new BorrowOrder(DateTime.Now, member, librarian, new Item(1, 727));
+
+            //Create 4 orders
+            rep.AddAsync(order);
+            rep.AddAsync(order);
+            rep.AddAsync(order);
+            rep.AddAsync(order);
+
+            Assert.Equal(4, await rep.GetCountOfUnreturnedOrders(1234556)); 
+        }
+    }
+}


### PR DESCRIPTION
add 5 books check 